### PR TITLE
Update trackleaders.py

### DIFF
--- a/trackleaders.py
+++ b/trackleaders.py
@@ -45,7 +45,7 @@ def make_datetime_converter():
     '''
     convert timestamp to a datetime
     '''
-    now = datetime.now()
+    now = datetime(2016, 9, 13, 11, 18) # trackleaders archive datetime
     def converter(ts):
         delta = timedelta(days=ts['days'],
                 hours=ts['hours'],


### PR DESCRIPTION
Looks like the 2016 trans am was archived on 9/13/2016 at 11:18am. I derived the date from Steffen's first point at the start, with the title stuck on "101 days, 3 hours, 28 minutes ago", and just found the difference with the race start datetime (6/4/2016 at 8:00am)

http://trackleaders.com/spot/transam16/Steffen_Streich.js